### PR TITLE
Update WebSocketServer.js

### DIFF
--- a/server/lib/WebSocketServer.js
+++ b/server/lib/WebSocketServer.js
@@ -12,8 +12,8 @@ module.exports = class WebSocketServer {
     wss.on('connection', ws => {
       const type = ws.type;
       if (type === 'target') {
-        const { id, url, title, favicon } = ws;
-        this.channelManager.createTarget(id, ws, url, title, favicon);
+        const { id, chiiUrl , title, favicon } = ws;
+        this.channelManager.createTarget(id, ws, chiiUrl, title, favicon);
       } else {
         const { id, target } = ws;
         this.channelManager.createClient(id, ws, target);
@@ -36,7 +36,7 @@ module.exports = class WebSocketServer {
           ws.id = id;
           const q = query.parse(urlObj.query);
           if (type === 'target') {
-            ws.url = q.url;
+            ws.chiiUrl = q.url;
             ws.title = q.title;
             ws.favicon = q.favicon;
           } else {


### PR DESCRIPTION
TypeError: Cannot set property url of #<WebSocket> which has only a getter.
Seems that WebSocket use the `url` field and make it readonly.